### PR TITLE
Fix: missing `become` results in apt package installation failures

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -1,5 +1,6 @@
 - hosts: gitea_servers
-
+  become: true
+  
   roles:
     # This role has no tasks at all
     - role: galaxy/com.devture.ansible.role.playbook_help


### PR DESCRIPTION
Fix: missing `become` results in apt package installation failures

Running the book with `-K` did not have the desired effect without having `become: true`